### PR TITLE
Update minify.php

### DIFF
--- a/minify/engine/plug/minify.php
+++ b/minify/engine/plug/minify.php
@@ -120,7 +120,7 @@ $css = function(string $in, int $comment = 2, int $quote = 2) use(
                 $out = explode('}', $out);
                 array_pop($out);
                 array_pop($out);
-                // '}' concatenated to the end of the implode() function
+                // `}` concatenated to the end of the implode() function
                 // to fix the problem with the closing brace not appearing
                 // at the end of the CSS selector
                 $out = implode('}', $out) . '}';


### PR DESCRIPTION
The original code results in a syntax error in the style sheet because the CSS selector containing the styles lacks the closing brace after the removal of empty selector, which is done inside the if statement block starting in Line 119.
For a quick fix, '}' concatenated to the end of the implode() function (at Line 126) to fix the problem with the closing brace not appearing at the end of the CSS selector.