### PR TITLE
Update minify.php

### DIFF
--- a/minify/engine/plug/minify.php
+++ b/minify/engine/plug/minify.php
@@ -200,11 +200,18 @@ $css_minify = static function(string $in) use(
         '/:0(?: 0){1,3}([};,])/',
         '/\bbackground:(?:none|0)\b/',
         '/\b(border(?:-radius)?|outline):none\b/'
+        '/screen and/', // Temp fix: adds space after `screen and`
+        // Added from the `fn_minify_css_union()` function of the earlier version
+        // Replace `0.6` with `.6` [^6]
+        '#\b0+\.(\d+)#'
     ], [
         ' ',
         ':0$1',
         'background:0 0',
-        '$1:0'
+        '$1:0',
+        '$0 ',
+        // [^6]
+        '.$1'
     ], $out);
 };
 


### PR DESCRIPTION
The code results in a syntax error in the CSS style sheet output because media queries targeting a screen device don't have a space between the 'and' keyword and the opening parenthesis of media features. For a quick fix, the following pattern '/screen and/' and the replacement string '$0 ' added to the preg_replace() function (at Line 198).
Additionally, parameters are added to the function to remove leading zeros from the beginning of a number before the decimal point in a string.